### PR TITLE
Fix comment only command and update activity payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-love/producthunt",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Integrate Product Hunt votes into Orbit workspaces",
   "main": "./src/index.js",
   "bin": "./src/bin.js",

--- a/src/bin.js
+++ b/src/bin.js
@@ -6,10 +6,11 @@ const args = require('yargs').argv
 async function main() {
     const hasEnvVars = process.env.ORBIT_WORKSPACE_ID && process.env.ORBIT_API_KEY && process.env.PRODUCT_HUNT_API_KEY && process.env.PRODUCT_HUNT_API_SECRET
     const hasVoteReqs = args.votes && args.id
+    const hasCommentReqs = args.comments && args.id
     const hasProductReqs = args.products && args.user
     const hasBothReqs = args.votes && args.products
 
-    if(!hasEnvVars || !(hasVoteReqs || hasProductReqs) || hasBothReqs) {
+    if(!hasEnvVars || !(hasVoteReqs || hasProductReqs || hasCommentReqs) || hasBothReqs) {
         return console.error(`
         You may only run any of the following commands:
         npx @orbit-love/producthunt --products --user=username

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,10 @@ class OrbitProductHunt {
       return {
         activity: {
           title: `Upvoted on Product Hunt`,
-          tags: ['channel:producthunt', `product:${item.post_id}`, `product_url:${item.post_url}`],
+          //tags: ['channel:producthunt', `product_id:${item.post_id}`],
+          properties: {
+            product_id: `${item.post_id}`,
+          },
           activity_type_key: 'producthunt:vote',
           key: `producthunt-vote-${item.id}`,
           occurred_at: new Date(item.created_at).toISOString(),
@@ -169,7 +172,11 @@ class OrbitProductHunt {
         activity: {
           title: `Commented on Product Hunt`,
           description: item.body,
-          tags: ['channel:producthunt', `product:${item.post_id}`, `product_url:${item.post_url}`],
+          //tags: ['channel:producthunt', `product:${item.post_id}`, `product_url:${item.url}`],
+          properties: {
+            product: `${item.post_id}`,
+            product_url: `${item.url.split('?')[0]}`
+          },
           activity_type_key: 'producthunt:comment',
           key: `producthunt-comment-${item.id}`,
           occurred_at: new Date(item.created_at).toISOString(),

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,6 @@ class OrbitProductHunt {
       return {
         activity: {
           title: `Upvoted on Product Hunt`,
-          //tags: ['channel:producthunt', `product_id:${item.post_id}`],
           properties: {
             product_id: `${item.post_id}`,
           },
@@ -172,7 +171,6 @@ class OrbitProductHunt {
         activity: {
           title: `Commented on Product Hunt`,
           description: item.body,
-          //tags: ['channel:producthunt', `product:${item.post_id}`, `product_url:${item.url}`],
           properties: {
             product: `${item.post_id}`,
             product_url: `${item.url.split('?')[0]}`

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,8 @@ class OrbitProductHunt {
       return {
         activity: {
           title: `Upvoted on Product Hunt`,
-          tags: ['channel:producthunt'],
-          activity_type: 'producthunt:vote',
+          tags: ['channel:producthunt', `product:${item.post_id}`, `product_url:${item.post_url}`],
+          activity_type_key: 'producthunt:vote',
           key: `producthunt-vote-${item.id}`,
           occurred_at: new Date(item.created_at).toISOString(),
           member: { twitter: item.user.twitter_username }
@@ -169,8 +169,8 @@ class OrbitProductHunt {
         activity: {
           title: `Commented on Product Hunt`,
           description: item.body,
-          tags: ['channel:producthunt'],
-          activity_type: 'producthunt:comment',
+          tags: ['channel:producthunt', `product:${item.post_id}`, `product_url:${item.post_url}`],
+          activity_type_key: 'producthunt:comment',
           key: `producthunt-comment-${item.id}`,
           occurred_at: new Date(item.created_at).toISOString(),
           link: item.url,


### PR DESCRIPTION
`--comments` used alone as a command line flag now works and the payload for activities has been updated to use the `activity_type_key` and `properties` with additional context